### PR TITLE
added processes arg to executor call

### DIFF
--- a/blackbox.py
+++ b/blackbox.py
@@ -96,7 +96,7 @@ def search_min(f, domain, budget, batch, resfile,
         print('[blackbox] evaluating batch %s/%s (samples %s..%s/%s) @ ' % (i+1, (n+m)//batch, i*batch+1, (i+1)*batch, n+m) + \
         str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")) + ' ...')
 
-        with executor() as e:
+        with executor(processes=batch) as e:
             points[batch*i:batch*(i+1), -1] = list(e.map(f, list(map(cubetobox, points[batch*i:batch*(i+1), 0:-1]))))
 
     # normalizing function values
@@ -129,7 +129,7 @@ def search_min(f, domain, budget, batch, resfile,
                     break
             points[n+i*batch+j, 0:-1] = np.copy(minfit.x)
 
-        with executor() as e:
+        with executor(processes=batch) as e:
             points[n+batch*i:n+batch*(i+1), -1] = list(e.map(f, list(map(cubetobox, points[n+batch*i:n+batch*(i+1), 0:-1]))))/fmax
 
     # saving results into text file


### PR DESCRIPTION
Using a distributed job submission platform to submit the function evaluation calls to a cluster. It seemed that the number of evaluations run in parallel was lower than what I set it to with the "batch" parameter. Reading through the Python doc for `multiprocessing.Pool`, the default for the `processes `argument is the number of cores on the local machine. Setting `processes=batch` solved the problem, allowing the number of evaluations set to run in parallel.