### PR TITLE
insure int type for math.factorial

### DIFF
--- a/black_box/blackbox.py
+++ b/black_box/blackbox.py
@@ -3,6 +3,7 @@ import multiprocessing as mp
 import numpy as np
 import scipy.optimize as op
 import datetime
+import math
 
 
 def search_min(f, domain, budget, batch, resfile,
@@ -78,9 +79,9 @@ def search_min(f, domain, budget, batch, resfile,
 
     # volume of d-dimensional ball (r = 1)
     if d % 2 == 0:
-        v1 = np.pi**(d/2)/np.math.factorial(d/2)
+        v1 = np.pi**(d/2)/math.factorial(int(d/2))
     else:
-        v1 = 2*(4*np.pi)**((d-1)/2)*np.math.factorial((d-1)/2)/np.math.factorial(d)
+        v1 = 2*(4*np.pi)**((d-1)/2)*math.factorial(int((d-1)/2))/np.math.factorial(d)
 
     # subsequent iterations (current subsequent iteration = i*batch+j)
 


### PR DESCRIPTION
https://bugs.python.org/issue37315
Accepting floats for math.factorial was removed. since d is either even or manipulated to be even, it should be safe to convert to an integer.
https://stackoverflow.com/questions/21753841/factorial-in-numpy-and-scipy
math.factorial and np.math.factorial is the same thing