### PR TITLE
Fix: TypeError: 'float' object cannot be interpreted as an integer

### DIFF
--- a/blackbox/blackbox.py
+++ b/blackbox/blackbox.py
@@ -162,7 +162,7 @@ def compute_volume_unit_ball(d: int) -> float:
         float: volume
     """
     if d % 2 == 0:
-        v1 = np.pi ** (d / 2) / np.math.factorial(d / 2)
+        v1 = np.pi ** (d / 2) / np.math.factorial(d // 2)
     else:
         v1 = (
             2


### PR DESCRIPTION
Quick fix for error
```
TypeError: 'float' object cannot be interpreted as an integer
```
Same issue with https://github.com/paulknysh/blackbox/issues/29

Python: 3.10.14
OS: Ubuntu 24.04