### PR TITLE
Allow Python versions greater than 3.9.7

### DIFF
--- a/blackbox/blackbox.py
+++ b/blackbox/blackbox.py
@@ -162,12 +162,12 @@ def compute_volume_unit_ball(d: int) -> float:
         float: volume
     """
     if d % 2 == 0:
-        v1 = np.pi ** (d / 2) / np.math.factorial(d / 2)
+        v1 = np.pi ** (d / 2) / np.math.factorial(d // 2)
     else:
         v1 = (
             2
             * (4 * np.pi) ** ((d - 1) / 2)
-            * np.math.factorial((d - 1) / 2)
+            * np.math.factorial((d - 1) // 2)
             / np.math.factorial(d)
         )
     return v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Python module for parallel optimization of expensive black-box 
 authors = ["Paul Knysh"]
 
 [tool.poetry.dependencies]
-python = "~3.9.7"
+python = ">=3.9.7"
 numpy = "^1.23.0"
 scipy = "^1.9.0"
 


### PR DESCRIPTION
Fixes #33.

Note I was a little lazy here in setting up the PR, since I applied the patch of the python version on top of the patch using integer division, as that way I could use it locally as a dependency. Let me know if you'd prefer that I change this.